### PR TITLE
Removed duplicate core import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@ JDK 7 data types.
 
     <!-- Configuration properties for the OSGi maven-bundle-plugin -->
     <osgi.import>com.fasterxml.jackson.core
-,com.fasterxml.jackson.core
 ,com.fasterxml.jackson.core.util
 ,com.fasterxml.jackson.databind
 ,com.fasterxml.jackson.databind.deser.std


### PR DESCRIPTION
Knopflerfish that I am using for a project doesn't like duplicate imports... And I see no reason for it to be there.
